### PR TITLE
Provide warning message for syntax errors

### DIFF
--- a/src/edn_config/core.clj
+++ b/src/edn_config/core.clj
@@ -9,6 +9,7 @@
   (try
     (with-open [r (-> "config.edn" io/resource io/reader PushbackReader.)]
     (edn/read r))
-    (catch Exception _)))
+    (catch Exception e
+      (println (str "WARNING: edn-config: " (.getLocalizedMessage e))))))
 
 (defonce env (merge (read-config-file) environ/env))


### PR DESCRIPTION
This PR gives developers a friendly warning when their config has a syntax
error so they can more quickly figure out why their env doesn't have the values
they expect.
