### PR TITLE
Fix merge order for config.edn to override.

### DIFF
--- a/src/config/core.clj
+++ b/src/config/core.clj
@@ -46,10 +46,9 @@
 (defonce ^{:doc "A map of environment variables."}
   env
   (let [env-props (merge (read-system-env) (read-system-props))]
-    (merge
-      (read-config-file "config.edn")
-      (read-env-file (:config env-props))
-      (read-env-file ".lein-env")
-      (read-env-file (io/resource ".boot-env"))
-      env-props)))
+    (merge env-props
+           (read-env-file (:config env-props))
+           (read-env-file ".lein-env")
+           (read-env-file (io/resource ".boot-env"))
+           (read-config-file "config.edn"))))
 


### PR DESCRIPTION
Want to override existing environment with "config.edn" and not exisiting environment override "config.edn".

``` clojure
=> (merge {:a 1} {})
;; => {:a 1}

=> (merge {:a {:b 2}} {})
;; => {:a {:b 2}}

;;  If you define a :dev-overrides in project.clj as empty map, it will
;; override your config.edn wannabe override :dev-overrides.
=> (merge {:a {:b 2}} {:a {}})
;; =>{:a {}}
```