### PR TITLE
Add ability to reload environment

### DIFF
--- a/src/config/core.clj
+++ b/src/config/core.clj
@@ -100,3 +100,6 @@
 (defonce
   ^{:doc "A map of environment variables."}
   env (load-env))
+
+(defn reload-env []
+  (alter-var-root #'env (fn [_] (load-env))))

--- a/src/config/core.clj
+++ b/src/config/core.clj
@@ -6,10 +6,11 @@
   (:import java.io.PushbackReader))
 
 ;originally found in cprop https://github.com/tolitius/cprop/blob/6963f8e04fd093744555f990c93747e0e5889395/src/cprop/source.cljc#L26
-(defn- str->value [v]
+(defn- str->value
   "ENV vars and system properties are strings. str->value will convert:
    the numbers to longs, the alphanumeric values to strings, and will use Clojure reader for the rest
    in case reader can't read OR it reads a symbol, the value will be returned as is (a string)"
+  [v]
   (cond
     (re-matches #"[0-9]+" v) (Long/parseLong v)
     (re-matches #"^(true|false)$" v) (Boolean/parseBoolean v)


### PR DESCRIPTION
This is a small PR which adds a new `reload-env` function in `config.core`.

I use this library in many projects, and always end up adding this function in each of them, in order to avoid having to restart my REPL when I change my local development configuration.