### PR TITLE
Fix typo in jvm-opts in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ We will add the dependency to our `project.clj` file and specify the configurati
   :dependencies [[org.clojure/clojure "1.10.0"]
                  [yogthos/config <VERSION>]]
   ;; configuration will be read from the dev-config.edn file               
-  :jvm-opts ["-Dconf=dev-config.edn"]               
+  :jvm-opts ["-Dconfig=dev-config.edn"]               
   :main edn-config-test.core)
 
 ```


### PR DESCRIPTION
In `jvm-opts` it should be `-Dconfig=...` instead of `-Dconf`. It took me an embarrassingly long time to figure out what I was doing wrong :-)