### PR TITLE
Don't sanitize keys when reading EDN files

### DIFF
--- a/src/config/core.clj
+++ b/src/config/core.clj
@@ -52,8 +52,7 @@
   (try
     (when-let [env-file (io/file f)]
       (when (.exists env-file)
-        (into {} (for [[k v] (edn/read-string (slurp env-file))]
-                   [(sanitize-key k) v]))))
+        (edn/read-string (slurp env-file))))
     (catch Exception e
       (log/warn (str "WARNING: failed to parse " f " " (.getLocalizedMessage e))))))
 


### PR DESCRIPTION
Makes behaviour when reading config from classpath and from a file specified on the command line consistent. Previously namespaced, underscore-cased, or upper or mixed case keywords would have been supported in config files on the classpath but not in config files specified on the command line when running a jar.

Closes #18.