### PR TITLE
fix: exception on parsing errors #23

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,5 +3,4 @@
   :url "https://github.com/yogthos/config"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.10.3"]
-                 [org.clojure/tools.logging "1.2.1"]])
+  :dependencies [[org.clojure/clojure "1.10.3"]])


### PR DESCRIPTION
Syntax errors in config files are now throwing an Exception.

If a file was specified using the CONFIG environment variable, it must
exist. Otherwise an FileNotFoundException is thrown.

And as a nice side effect: yogthos/config has no more dependencies :)